### PR TITLE
Fix compile error in `Game.cs`

### DIFF
--- a/code/Game.cs
+++ b/code/Game.cs
@@ -71,38 +71,38 @@ namespace TTTReborn.Gamemode
 
             base.ClientDisconnect(client, reason);
         }
-    }
 
-    public override void PostLevelLoaded()
-    {
-        _ = StartGameTimer();
-
-        base.PostLevelLoaded();
-    }
-
-    private async Task StartGameTimer()
-    {
-        ChangeRound(new WaitingRound());
-
-        while (true)
+        public override void PostLevelLoaded()
         {
-            await Task.DelaySeconds(1);
+            _ = StartGameTimer();
 
-            OnGameSecond();
+            base.PostLevelLoaded();
         }
-    }
 
-    public void ChangeRound(BaseRound round)
-    {
-        Assert.NotNull(round);
+        private async Task StartGameTimer()
+        {
+            ChangeRound(new WaitingRound());
 
-        Round?.Finish();
-        Round = round;
-        Round?.Start();
-    }
+            while (true)
+            {
+                await Task.DelaySeconds(1);
 
-    private void OnGameSecond()
-    {
-        Round?.OnSecond();
+                OnGameSecond();
+            }
+        }
+
+        public void ChangeRound(BaseRound round)
+        {
+            Assert.NotNull(round);
+
+            Round?.Finish();
+            Round = round;
+            Round?.Start();
+        }
+
+        private void OnGameSecond()
+        {
+            Round?.OnSecond();
+        }
     }
 }


### PR DESCRIPTION
Not sure how this occurred, as my branch was compiling for sure. It may have been the auto combination between https://github.com/TTTReborn/ttt-reborn/pull/8 and https://github.com/TTTReborn/ttt-reborn/pull/7 ?

EDIT: Looks like it was already broken in our repo before https://github.com/TTTReborn/ttt-reborn/pull/8 was merged, so no idea. Anyways, basically this PR just moves these functions inside of the class definition.