### PR TITLE
Use UserId instead of SteamId for scoreboard

### DIFF
--- a/code/ui/generalhud/scoreboard/Scoreboard.cs
+++ b/code/ui/generalhud/scoreboard/Scoreboard.cs
@@ -22,9 +22,9 @@ namespace TTTReborn.UI
 
         public static Scoreboard Instance;
 
-        private readonly Dictionary<ulong, ScoreboardEntry> _entries = new();
+        private readonly Dictionary<int, ScoreboardEntry> _entries = new();
         private readonly Dictionary<string, ScoreboardGroup> _scoreboardGroups = new();
-        private readonly Dictionary<ulong, bool> _forcedSpecList = new();
+        private readonly Dictionary<int, bool> _forcedSpecList = new();
 
         private readonly Panel _backgroundPanel;
         private readonly Panel _scoreboardContainer;
@@ -107,15 +107,15 @@ namespace TTTReborn.UI
         }
 
         [Event(TTTEvent.Player.Disconnected)]
-        private void OnPlayerDisconnected(ulong steamId, NetworkDisconnectionReason reason)
+        private void OnPlayerDisconnected(int userId, NetworkDisconnectionReason reason)
         {
-            RemoveClient(steamId);
+            RemoveClient(userId);
             UpdateScoreboardGroups();
         }
 
         public void AddClient(Client client)
         {
-            if (_entries.TryGetValue(client.SteamId, out ScoreboardEntry panel))
+            if (_entries.TryGetValue(client.UserId, out ScoreboardEntry panel))
             {
                 return;
             }
@@ -125,7 +125,7 @@ namespace TTTReborn.UI
 
             scoreboardGroup.GroupMembers++;
 
-            _entries.Add(client.SteamId, scoreboardEntry);
+            _entries.Add(client.UserId, scoreboardEntry);
 
             scoreboardGroup.UpdateLabel();
             _scoreboardHeader.UpdateServerInfo();
@@ -133,7 +133,7 @@ namespace TTTReborn.UI
 
         public void UpdateClient(Client client)
         {
-            if (!_entries.TryGetValue(client.SteamId, out ScoreboardEntry panel))
+            if (!_entries.TryGetValue(client.UserId, out ScoreboardEntry panel))
             {
                 return;
             }
@@ -143,7 +143,7 @@ namespace TTTReborn.UI
             if (scoreboardGroup.GroupTitle != panel.ScoreboardGroupName)
             {
                 // instead of remove and add, move the panel into the right parent
-                RemoveClient(client.SteamId);
+                RemoveClient(client.UserId);
                 AddClient(client);
             }
             else
@@ -162,9 +162,9 @@ namespace TTTReborn.UI
             }
         }
 
-        public void RemoveClient(ulong steamId)
+        public void RemoveClient(int userId)
         {
-            if (!_entries.TryGetValue(steamId, out ScoreboardEntry panel))
+            if (!_entries.TryGetValue(userId, out ScoreboardEntry panel))
             {
                 return;
             }
@@ -179,7 +179,7 @@ namespace TTTReborn.UI
             scoreboardGroup.UpdateLabel();
 
             panel.Delete();
-            _entries.Remove(steamId);
+            _entries.Remove(userId);
         }
 
         public override void Tick()
@@ -191,13 +191,13 @@ namespace TTTReborn.UI
             {
                 bool newIsForcedSpectator = client.GetValue<bool>("forcedspectator");
 
-                if (!_forcedSpecList.TryGetValue(client.SteamId, out bool isForcedSpectator))
+                if (!_forcedSpecList.TryGetValue(client.UserId, out bool isForcedSpectator))
                 {
-                    _forcedSpecList.Add(client.SteamId, newIsForcedSpectator);
+                    _forcedSpecList.Add(client.UserId, newIsForcedSpectator);
                 }
                 else if (isForcedSpectator != newIsForcedSpectator)
                 {
-                    _forcedSpecList[client.SteamId] = newIsForcedSpectator;
+                    _forcedSpecList[client.UserId] = newIsForcedSpectator;
 
                     UpdateClient(client);
                 }
@@ -231,7 +231,7 @@ namespace TTTReborn.UI
             {
                 group = DefaultScoreboardGroup.Spectator.ToString();
             }
-            else if (client.SteamId != 0 && client.Pawn is TTTPlayer player)
+            else if (client.Pawn is TTTPlayer player)
             {
                 if (player.IsConfirmed)
                 {


### PR DESCRIPTION
I'm open to hear thoughts about this, but since we use `SteamId` we are unable to test on a local machine since we have two users will have the same SteamId. It might be better to use `UserId` which is guaranteed to also be unique for each player.