### PR TITLE
Fix Winningteam on Timeup

### DIFF
--- a/code/rounds/InProgressRound.cs
+++ b/code/rounds/InProgressRound.cs
@@ -78,7 +78,7 @@ namespace TTTReborn.Rounds
 
         protected override void OnTimeUp()
         {
-            LoadPostRound(new InnocentTeam());
+            LoadPostRound(TeamFunctions.GetTeamByType(typeof(InnocentTeam)));
 
             base.OnTimeUp();
         }


### PR DESCRIPTION
The winning team was `Traitors` on timeup, it should be innocents.